### PR TITLE
Update repository URL to point to payjoin/ohttp

### DIFF
--- a/ohttp/Cargo.toml
+++ b/ohttp/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.63.0"
 build = "build.rs"
 license = "MIT OR Apache-2.0"
 description = "Oblivious HTTP over secp256k1 and ChaCha20Poly1305"
-repository = "https://github.com/payjoin/bitcoin-ohttp"
+repository = "https://github.com/payjoin/ohttp"
 
 [features]
 default = ["client", "server", "rust-hpke"]


### PR DESCRIPTION
Fix https://github.com/payjoin/rust-payjoin/issues/378

> On crates.io the repo URL for [bitcoin-ohttp](https://crates.io/crates/bitcoin-ohttp) is set to https://crates.io/crates/bitcoin-ohttp but looks like it should be https://github.com/payjoin/ohttp/tree/main/ohttp.  @DanGould is the owner on crates.io so he'll need to fix it.